### PR TITLE
Fix typo in admin config

### DIFF
--- a/client/src/app/+admin/config/edit-custom-config/edit-custom-config.component.html
+++ b/client/src/app/+admin/config/edit-custom-config/edit-custom-config.component.html
@@ -419,7 +419,7 @@
                 <div class="form-group" formGroupName="http">
                   <my-peertube-checkbox
                     inputName="importVideosHttpEnabled" formControlName="enabled"
-                    i18n-labelText labelText="Allow import with HTTP URL (i.e. YouTube)"
+                    i18n-labelText labelText="Allow import with HTTP URL (e.g. YouTube)"
                   ></my-peertube-checkbox>
                 </div>
 


### PR DESCRIPTION
## Description

>  e.g. is short for exempli gratia, a Latin phrase that means “for the sake of example.” 
> ...
>  I.e.’s Latin origin is the phrase id est, which translates to English as “that is to say” or “in other words.”

https://www.grammarly.com/blog/know-your-latin-i-e-vs-e-g/

- [x] 🙅 no, because they aren't needed

<!--
If you didn't test via unit-testing, you will still be asked to prove your fix is effective, doesn't have side-effects, or that your feature simply works:

Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration(s):
-->

## Screenshots

<!-- delete if not relevant -->
![image](https://user-images.githubusercontent.com/6680299/101885204-1ba91400-3b9a-11eb-91e6-7d6903edecf2.png)

